### PR TITLE
fix: stop checking a polygon after it is marked fully covered

### DIFF
--- a/src/imodulator/ElectroOpticalSimulator.py
+++ b/src/imodulator/ElectroOpticalSimulator.py
@@ -171,6 +171,7 @@ class ElectroOpticalSimulator:
                 if difference_poly.is_empty:
                     polygons_to_remove.append(poly_name)
                     print(f'The polygon "{poly_name}" is fully covered by a higher priority polygons. It will be removed from the simulation.')
+                    break
         
         #Remove the polygons that are fully covered by higher priority polygons
         for poly_name in polygons_to_remove:

--- a/src/imodulator/OpticalSimulator.py
+++ b/src/imodulator/OpticalSimulator.py
@@ -760,6 +760,7 @@ class OpticalSimulatorFEMWELL:
                 if difference_poly.is_empty:
                     polygons_to_remove.append(poly_name)
                     print(f'The polygon "{poly_name}" is fully covered by a higher priority polygons. It will be removed from the simulation.')
+                    break
         
         #Remove the polygons that are fully covered by higher priority polygons
         for poly_name in polygons_to_remove:

--- a/src/imodulator/RFSimulator.py
+++ b/src/imodulator/RFSimulator.py
@@ -211,6 +211,7 @@ class RFSimulatorFEMWELL:
                 if difference_poly.is_empty:
                     polygons_to_remove.append(poly_name)
                     print(f'The polygon "{poly_name}" is fully covered by a higher priority polygons. It will be removed from the simulation.')
+                    break
         
         #Remove the polygons that are fully covered by higher priority polygons
         for poly_name in polygons_to_remove:


### PR DESCRIPTION
Without the break, a polygon already found to be empty kept being diffed against remaining higher-priority polygons and could be added to polygons_to_remove multiple times, making the later pop() fail.

Fixes #24