### PR TITLE
Optional installs for femwell, solcore and nextnano

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,10 +9,36 @@ To use Imodulator, simply install via pip:
 .. code-block:: console
 
    (.venv) $ pip install imodulator
-   (.venv) $ pip install --no-deps git+https://github.com/HelgeGehring/femwell.git@36e2ff1d8507e3839f29b5f14c298a091b463c49
 
-The second line has been added as a temporary measure. New changes have been made in FEMWELL on the mesh refinement which have not been made into a release yet. Once a new FEMWELL release is made, it shall be added to the dependencies of Imodulator and the second line can be omitted.
-Alternatively you can close the repository and install it locally:
+The simulation backends are optional dependencies, installed as *extras* so you
+only pull in what you need:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Extra
+     - Enables
+   * - ``imodulator[femwell]``
+     - Optical and RF mode solving (``OpticalSimulatorFEMWELL``, ``RFSimulatorFEMWELL``, ``ElectroOpticalSimulator``)
+   * - ``imodulator[solcore]``
+     - Solcore-based charge transport (``ChargeSimulatorSolcore``)
+   * - ``imodulator[nextnanopy]``
+     - nextnano-based charge transport (``ChargeSimulatorNN``)
+   * - ``imodulator[all]``
+     - All of the above
+
+Extras combine, so you can request any subset in one command:
+
+.. code-block:: console
+
+   (.venv) $ pip install imodulator[femwell]
+   (.venv) $ pip install imodulator[nextnanopy,femwell]
+   (.venv) $ pip install imodulator[all]
+
+Instantiating a simulator whose extra is not installed raises a clear error
+telling you which ``pip install`` command to run.
+
+Alternatively you can clone the repository and install it locally:
 
 .. code-block:: console
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,6 +38,18 @@ Extras combine, so you can request any subset in one command:
 Instantiating a simulator whose extra is not installed raises a clear error
 telling you which ``pip install`` command to run.
 
+.. note::
+
+   ``solcore`` depends on ``solsesame==2.1a1``, which is a **pre-release**. Plain
+   ``pip`` (including inside a conda environment) installs it automatically
+   because the version is pinned exactly, but ``uv`` rejects pre-releases by
+   default. If you install the ``solcore`` extra with ``uv`` and hit a resolver
+   error, allow pre-releases explicitly:
+
+   .. code-block:: console
+
+      (.venv) $ uv pip install -e '.[solcore]' --prerelease=allow
+
 Alternatively you can clone the repository and install it locally:
 
 .. code-block:: console

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 femwell = ["femwell==0.1.11"]
 # Solcore-based charge transport (ChargeSimulatorSolcore). Install with:
 # pip install imodulator[solcore]
-solcore = ["solcore>=5.10.1"]
+solcore = ["solcore>=5.10.1"] # solcore depends on solsesame==2.1a1 (a pre-release); if install fails, add --prerelease=allow
 # nextnano-based charge transport (ChargeSimulatorNN). Install with:
 # pip install imodulator[nextnanopy]
 nextnanopy = ["nextnanopy>=1.2.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,7 @@ classifiers = [
 license = {file = "LICENSE"}
 keywords = ["integrated photonics", "electro-optic modulators", "photonics simulation", "optical mode solver", "rf mode solver", "charge transport simulation", "electro-optic interaction"]
 dependencies = [
-    "femwell==0.1.11",
     "scikit-fem>=12.0.0",
-    # "femwell @ git+https://github.com/HelgeGehring/femwell.git@36e2ff1d8507e3839f29b5f14c298a091b463c49",
     "matplotlib==3.9.0",
     "numpy>=2.2.6",
     "Pint>=0.24",
@@ -35,12 +33,21 @@ dependencies = [
     "shapely>=2.1.2",
     "pyyaml==6.0.2",
     "pandas==2.3.0",
-    "nextnanopy>=1.2.0",
     "openbandparams>=1.0",
-    "scikit-fem>=11.0.0",
     "pygmsh>=7.1.17",
-    "solcore>=5.10.1"
 ]
+
+[project.optional-dependencies]
+# Optical and RF mode solving (OpticalSimulatorFEMWELL, RFSimulatorFEMWELL,
+# ElectroOpticalSimulator). Install with: pip install imodulator[femwell]
+femwell = ["femwell==0.1.11"]
+# Solcore-based charge transport (ChargeSimulatorSolcore). Install with:
+# pip install imodulator[solcore]
+solcore = ["solcore>=5.10.1"]
+# nextnano-based charge transport (ChargeSimulatorNN). Install with:
+# pip install imodulator[nextnanopy]
+nextnanopy = ["nextnanopy>=1.2.0"]
+all = ["imodulator[femwell,solcore,nextnanopy]"]
 
 [project.urls]
 Homepage = "https://github.com/duarte-jfs/Imodulator"

--- a/src/imodulator/ChargeSimulator.py
+++ b/src/imodulator/ChargeSimulator.py
@@ -29,30 +29,40 @@ from imodulator.PhotonicPolygon import (
     InsulatorPolygon,
 )
 
-####### SOLCORE imports ##########
-from solcore.material_system.material_system import BaseMaterial
-from solcore.material_data.mobility import (
-    calculate_InAlAs,
-    calculate_InGaAs,
-    calculate_InGaAsP,
-    calculate_InGaP,
-    calculate_AlGaAs,
-    mobility_low_field,
-)
 import json
 import inspect
-
-import solcore
-from solcore import config
-from solcore.parameter_system import ParameterSystem
-from solcore.poisson_drift_diffusion.DeviceStructure import DefaultProperties
 from configparser import ConfigParser
 
-from solcore.solar_cell import Junction, SolarCell, Layer
-from solcore.state import State
-from solcore.solar_cell_solver import solar_cell_solver
-
 import gmsh
+
+from imodulator._optional_deps import require
+
+####### SOLCORE imports ##########
+# solcore is an optional dependency (pip install imodulator[solcore]). Import it
+# here without failing so `import imodulator.ChargeSimulator` (and ChargeSimulatorNN,
+# which does not need solcore) works when it is absent. Only ChargeSimulatorSolcore
+# and CustomMaterial_OBP require it, and they raise a clear error at instantiation.
+# BaseMaterial falls back to object so CustomMaterial_OBP can still be defined at
+# import time without solcore installed.
+try:
+    import solcore
+    from solcore import config
+    from solcore.material_system.material_system import BaseMaterial
+    from solcore.material_data.mobility import (
+        calculate_InAlAs,
+        calculate_InGaAs,
+        calculate_InGaAsP,
+        calculate_InGaP,
+        calculate_AlGaAs,
+        mobility_low_field,
+    )
+    from solcore.parameter_system import ParameterSystem
+    from solcore.poisson_drift_diffusion.DeviceStructure import DefaultProperties
+    from solcore.solar_cell import Junction, SolarCell, Layer
+    from solcore.state import State
+    from solcore.solar_cell_solver import solar_cell_solver
+except ModuleNotFoundError:
+    BaseMaterial = object
 
 PhotonicPolygon = SemiconductorPolygon | MetalPolygon | InsulatorPolygon
 Line = LineString | MultiLineString | LinearRing
@@ -147,8 +157,8 @@ class ChargeSimulatorNN:
         self,
         device: PhotonicDevice, 
         simulation_line: LineString,
-        inputfile_name: str ="quicksave", 
-        output_directory:str=nn.config.config['nextnano++']['outputdirectory'],
+        inputfile_name: str ="quicksave",
+        output_directory: str = None,
         temperature: float = 300.0,  # Add temperature parameter
         bias_start_stop_step: list = [0,1,2], #contact1 is the bias electrode decide - or + accordingly
         # save_sim: bool = False,
@@ -166,9 +176,13 @@ class ChargeSimulatorNN:
             bias_start_stop_step: Voltage sweep [start, stop, step]. Defaults to [0,1,1].
             
         """
-             
+        require("nextnanopy", "nextnanopy")
+
+        if output_directory is None:
+            output_directory = nn.config.config['nextnano++']['outputdirectory']
+
         self.temperature = temperature
-        self.inputfile_name = inputfile_name 
+        self.inputfile_name = inputfile_name
         self.output_directory = output_directory
         self.photonicdevice = device
         self.bias_start_stop_step=bias_start_stop_step
@@ -863,6 +877,7 @@ class ChargeSimulatorNN:
 class CustomMaterial_OBP(BaseMaterial):
 
     def __init__(self, name, opb_mat, T = 300, **kwargs):
+        require("solcore", "solcore")
         BaseMaterial.__init__(
             self,
             T=300, 
@@ -1367,6 +1382,8 @@ class ChargeSimulatorSolcore:
             bias_start_stop_step: Voltage sweep [start, stop, steps]. Defaults to [0,1,1].
             
         """
+        require("solcore", "solcore")
+
         self.temperature = temperature
         self.photonicdevice = device
         self.bias_start_stop_step=bias_start_stop_step

--- a/src/imodulator/ElectroOpticalSimulator.py
+++ b/src/imodulator/ElectroOpticalSimulator.py
@@ -21,7 +21,13 @@ from shapely.geometry import (
 )
 from shapely.ops import clip_by_rect
 
-from femwell.mesh import mesh_from_OrderedDict
+# femwell is an optional dependency (pip install imodulator[femwell]). Import it
+# here without failing so `import imodulator` works when it is absent;
+# ElectroOpticalSimulator raises a clear error at instantiation if it is missing.
+try:
+    from femwell.mesh import mesh_from_OrderedDict
+except ModuleNotFoundError:
+    pass
 
 from skfem.io.meshio import from_meshio
 from skfem.visuals.matplotlib import draw_mesh2d
@@ -36,6 +42,7 @@ from pint import Quantity
 
 from imodulator import PhotonicDevice
 from imodulator.ElectroOpticalModel import ElectroOpticalModel
+from imodulator._optional_deps import require
 
 from imodulator.PhotonicPolygon import (
     SemiconductorPolygon,
@@ -68,7 +75,8 @@ class ElectroOpticalSimulator:
             simulation_window (Polygon, optional): The polygon defining the simulation region. If None, the entire device is used.
             wavelength (float): The wavelength of the optical mode in nanometers. Default is 1550 nm.
         """
-        
+        require("femwell", "femwell")
+
         self.photodevice = device
         self.reg = self.photodevice.reg
         self.wl = wavelength * self.reg.nanometer

--- a/src/imodulator/OpticalSimulator.py
+++ b/src/imodulator/OpticalSimulator.py
@@ -31,18 +31,25 @@ from skfem import Basis, ElementTriP1, ElementVector, ElementDG, Functional
 from skfem.helpers import inner
 from skfem import adaptive_theta
 
-from femwell.mesh import mesh_from_OrderedDict
-from femwell.maxwell.waveguide import (
-    Modes,
-    Mode,
-    compute_modes,
-)
-
 import numpy as np
 import copy
 
+# femwell is an optional dependency (pip install imodulator[femwell]). Import it
+# here without failing so `import imodulator` works when it is absent;
+# OpticalSimulatorFEMWELL raises a clear error at instantiation if it is missing.
+try:
+    from femwell.mesh import mesh_from_OrderedDict
+    from femwell.maxwell.waveguide import (
+        Modes,
+        Mode,
+        compute_modes,
+    )
+except ModuleNotFoundError:
+    pass
+
 from imodulator import PhotonicDevice
 from imodulator.ElectroOpticalModel import ElectroOpticalModel
+from imodulator._optional_deps import require
 import imodulator.Config as Config
 lumapi=Config.config_instance.get_lumapi()
 
@@ -676,6 +683,8 @@ class OpticalSimulatorFEMWELL:
             include_metals: if `True`, :class:`MetalPolygon`s will be included in the simulation. If `False`, they will be ignored and their optical properties assigned to :math:`\epsilon_{opt} = 1`.
 
         '''
+        require("femwell", "femwell")
+
         self.photonicdevice = device
         self.reg = self.photonicdevice.reg
 

--- a/src/imodulator/RFSimulator.py
+++ b/src/imodulator/RFSimulator.py
@@ -17,19 +17,26 @@ from skfem import Basis, ElementTriP0, ElementTriP1, ElementVector, ElementDG, F
 from skfem.helpers import inner
 from skfem import adaptive_theta
 
-from femwell.mesh import mesh_from_OrderedDict
-from femwell.maxwell.waveguide import (
-    Modes,
-    Mode,
-    calculate_scalar_product,
-    compute_modes,
-)
+# femwell is an optional dependency (pip install imodulator[femwell]). Import it
+# here without failing so `import imodulator` works when it is absent;
+# RFSimulatorFEMWELL raises a clear error at instantiation if it is missing.
+try:
+    from femwell.mesh import mesh_from_OrderedDict
+    from femwell.maxwell.waveguide import (
+        Modes,
+        Mode,
+        calculate_scalar_product,
+        compute_modes,
+    )
+except ModuleNotFoundError:
+    pass
 
 import numpy as np
 import copy
 from pint import Quantity
 
 from imodulator import PhotonicDevice
+from imodulator._optional_deps import require
 from collections import OrderedDict
 import warnings
 
@@ -76,6 +83,7 @@ class RFSimulatorFEMWELL:
             The simulation window MUST be a rectangle. If not, the simulation will fail. Also beware that the definition of the simulation window is how you can make use of symmetry planes through the definition of metal boundaries or not. See `compute_modes` for more information on how to use the symmetry planes.
         
         """
+        require("femwell", "femwell")
 
         self.photodevice = device
         self.reg = self.photodevice.reg

--- a/src/imodulator/_optional_deps.py
+++ b/src/imodulator/_optional_deps.py
@@ -1,0 +1,23 @@
+"""Helpers for optional dependencies (femwell, solcore).
+
+These packages are declared as pip extras rather than hard requirements, so a
+plain ``import`` of imodulator (or of a simulator that does not need them)
+succeeds without them installed. Call :func:`require` at the point of use to
+turn a missing package into an actionable message.
+"""
+
+import importlib
+
+
+def require(package, extra):
+    """Import ``package``, or raise with the install command for its extra.
+
+    Returns the imported module so callers can also use it directly.
+    """
+    try:
+        return importlib.import_module(package)
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            f"'{package}' is required for this feature but is not installed. "
+            f"Install it with:  pip install imodulator[{extra}]"
+        ) from exc


### PR DESCRIPTION
## Summary

The heavy simulation backends — **femwell**, **solcore**, and **nextnanopy** — are now *optional* dependencies instead of hard requirements. `pip install imodulator` pulls in only the lightweight core; each backend is opted into via a pip extra (`imodulator[femwell]`, `imodulator[solcore]`, `imodulator[nextnanopy]`, or `imodulator[all]`), and extras combine in a single command (e.g. `imodulator[nextnanopy,femwell]`).

Backend imports are deferred so `import imodulator` succeeds even when a backend is absent, and a simulator that needs a missing backend raises a clear, actionable error **at instantiation**. As a result `ChargeSimulatorNN` (nextnano) works without solcore installed, and vice-versa.

## The pattern

Each backend is imported once, at the top of the module, guarded so a missing package doesn't break `import imodulator` — for example in [`RFSimulator.py` (L23–L32)](https://github.com/duarte-jfs/Imodulator/blob/ab2513d73c9e24fc6abfddf6689d9b7e8e4188e0/src/imodulator/RFSimulator.py#L23-L32):

```python
try:
    from femwell.mesh import mesh_from_OrderedDict
    from femwell.maxwell.waveguide import (
        Modes,
        Mode,
        calculate_scalar_product,
        compute_modes,
    )
except ModuleNotFoundError:
    pass
```

The solver's `__init__` then verifies the backend is present and, if not, raises a friendly error telling the user which extra to install — [`RFSimulator.py` (L86)](https://github.com/duarte-jfs/Imodulator/blob/ab2513d73c9e24fc6abfddf6689d9b7e8e4188e0/src/imodulator/RFSimulator.py#L86):

```python
require("femwell", "femwell")
```

where `require` is the small helper defined in [`_optional_deps.py` (L12)](https://github.com/duarte-jfs/Imodulator/blob/ab2513d73c9e24fc6abfddf6689d9b7e8e4188e0/src/imodulator/_optional_deps.py#L12):

```python
def require(package, extra):
    try:
        return importlib.import_module(package)
    except ModuleNotFoundError as exc:
        raise ModuleNotFoundError(
            f"'{package}' is required for this feature but is not installed. "
            f"Install it with:  pip install imodulator[{extra}]"
        ) from exc
```

The same pattern is applied to `OpticalSimulator.py`, `ElectroOpticalSimulator.py` (femwell), and `ChargeSimulator.py` (solcore + nextnanopy).

## Changes

- `pyproject.toml`: moved `femwell`, `solcore`, `nextnanopy` out of `dependencies` into `[project.optional-dependencies]` (plus an `all` alias); removed a duplicate `scikit-fem` entry.
- New `src/imodulator/_optional_deps.py` with the `require()` helper.
- Guarded backend imports + `require(...)` guards in the four simulator modules.
- `ChargeSimulator.py`: moved the `nn.config…` default out of `ChargeSimulatorNN.__init__`'s signature (it was evaluated at import, which effectively made nextnanopy mandatory); `BaseMaterial` falls back to `object` so `CustomMaterial_OBP` can still be defined without solcore.
- `docs/install.rst`: documents the extras, combined installs, and the `uv --prerelease=allow` note for solcore's `solsesame` pre-release dependency.

## Notes

- solcore depends on `solsesame==2.1a1` (a pre-release). Plain `pip` (including inside conda) installs it automatically; `uv` needs `--prerelease=allow`.
